### PR TITLE
topページ表示と各先生詳細ページへの遷移機能を追加

### DIFF
--- a/components/top/TopTeacherProfileCard.js
+++ b/components/top/TopTeacherProfileCard.js
@@ -1,13 +1,25 @@
 import Subject from "../common/selectButtons/SubjectButton";
 import IconBig from "../common/icon/BigIcon";
+import Router from "next/router";
 
-export default function TopProfile() {
+export default function TopProfile(props) {
+  const { teacher } = props;
+
+  const handleMoveToDetailPage = (id) => {
+    Router.push({
+      pathname: "/topTeacherDetail",
+      query: { id: id }
+    });
+  }
+
   return (
-    <div className="w-52 h-72 py-3 mx-3 mb-3 bg-card-gray rounded-md flex flex-col justify-center items-center text-gray-700">
-      <IconBig />
-      <p className="mt-3 mb-1">河野　玄太郎</p>
-      <p className="my-1 px-6 text-center">数学を嫌いから好きにします！</p>
-      <Subject />
+    <div 
+      onClick={() => handleMoveToDetailPage(teacher.id)}
+      className="w-52 h-72 py-3 mx-3 mb-3 bg-card-gray rounded-md flex flex-col justify-center items-center text-gray-700">
+        <IconBig />
+        <p className="mt-3 mb-1">{teacher.name}</p>
+        <p className="my-1 px-6 text-center">{teacher.title}</p>
+        <Subject />
     </div>
   );
 }

--- a/components/top/teacherDetail/ConsultationButton.js
+++ b/components/top/teacherDetail/ConsultationButton.js
@@ -1,9 +1,35 @@
+import { Modal, ModalCloseButton, ModalContent, ModalOverlay, Textarea, useDisclosure } from "@chakra-ui/react";
+
 export default function Consultation() {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const handleMessageSend = () => {
+
+  }
+
   return (
     <>
-      <button className="bg-origin-blue hover:bg-origin-deepBlue text-white px-2 py-1 my-3 rounded">
+      <button onClick={onOpen} className="bg-origin-blue hover:bg-origin-deepBlue text-white px-2 py-1 my-3 rounded">
         相談する
       </button>
+
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+
+        <ModalContent className="w-{400px}">
+        <ModalCloseButton />
+          <p className="mx-auto text-lg text-gray-700 my-8 font-bold">
+            先生にメッセージを送信しましょう！
+          </p>
+          <textarea className="w-72 h-24 mx-auto border border-gray-300 text-gray-700 rounded py-3 px-4 mb-3"></textarea>
+          <button
+            onClick={handleMessageSend}
+            className="mx-auto mt-5 mb-10 bg-transparent font-semibold text-origin-purple border border-origin-purple hover:bg-origin-purple hover:text-white py-2 w-40 rounded"
+          >
+            送信
+          </button>
+        </ModalContent>
+      </Modal>
     </>
+    
   );
 }

--- a/components/top/teacherDetail/TopTeacherProfileDetailCard.tsx
+++ b/components/top/teacherDetail/TopTeacherProfileDetailCard.tsx
@@ -10,7 +10,7 @@ export default function TopTeacherProfileDetailCard(props) {
       <p className="my-1">Profile</p>
       <IconBig />
       <p className="mt-3 mb-1">{teacher.name}</p>
-      <Consultation />
+      <Consultation teacher={teacher}/>
       <p className="my-1">実績</p>
 
       <p className="my-1">専門</p>
@@ -18,16 +18,16 @@ export default function TopTeacherProfileDetailCard(props) {
 
       <p className="my-1">担当科目</p>
       <div className="justify-center flex flex-wrap">
-      {(teacher.subjects.length > 0) && teacher.subjects.map((subject, index) => (
+      {teacher.subjects?.length > 0 && teacher.subjects.map((subject, index) => (
         <p key={index} className={buttonStyle}>{subject}</p>
       ))}
       </div>
 
       <p className="my-1">相談方法</p>
-        {teacher.consult.chat && (
+        {teacher.consult?.chat && (
           <p className={buttonStyle}>チャット</p>
         )}
-        {teacher.consult.video && (
+        {teacher.consult?.video && (
           <p className={buttonStyle}>ビデオ通話</p>
         )}
     </div>

--- a/components/top/teacherDetail/TopTeacherProfileDetailCard.tsx
+++ b/components/top/teacherDetail/TopTeacherProfileDetailCard.tsx
@@ -1,0 +1,35 @@
+import Consultation from "../../top/teacherDetail/ConsultationButton";
+import IconBig from "../../common/icon/BigIcon";
+
+export default function TopTeacherProfileDetailCard(props) {
+  const { teacher } = props;
+  const buttonStyle = "bg-white text-origin-purple px-1 my-1 mx-1 rounded"
+  
+  return (
+    <div className="w-52 py-5 bg-card-purple rounded-md flex flex-col justify-center items-center text-gray-700">
+      <p className="my-1">Profile</p>
+      <IconBig />
+      <p className="mt-3 mb-1">{teacher.name}</p>
+      <Consultation />
+      <p className="my-1">実績</p>
+
+      <p className="my-1">専門</p>
+      <p className={buttonStyle}>{teacher.category}</p>
+
+      <p className="my-1">担当科目</p>
+      <div className="justify-center flex flex-wrap">
+      {(teacher.subjects.length > 0) && teacher.subjects.map((subject, index) => (
+        <p key={index} className={buttonStyle}>{subject}</p>
+      ))}
+      </div>
+
+      <p className="my-1">相談方法</p>
+        {teacher.consult.chat && (
+          <p className={buttonStyle}>チャット</p>
+        )}
+        {teacher.consult.video && (
+          <p className={buttonStyle}>ビデオ通話</p>
+        )}
+    </div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,8 +2,31 @@ import Head from "next/head";
 import Header from "../components/common/header/header";
 import TopLeftMenu from "../components/top/TopLeftMenu";
 import TopProfile from "../components/top/TopTeacherProfileCard";
+import { collection, doc, getDoc, getDocs } from "firebase/firestore";
+import { db } from "../src/firabase"
+import { useEffect, useState } from "react";
 
 export default function Home() {
+  const [teachers, setTeachers] = useState([])
+
+  useEffect(() => {
+    const teacherRef = getDocs(collection(db, "TeacherUsers"));
+    console.log(teacherRef)
+    teacherRef.then(snapshot => {
+     const teachers = snapshot.docs.map((doc) => {
+        const id = doc.id;
+        const name = doc.data().name;
+        const title = doc.data().title;
+        const status = doc.data().status;
+         return { id, name, title, status }
+      })
+      setTeachers(teachers.filter(function(teacher) {
+        return teacher.status == true;
+      }))
+
+    })
+  }, [])
+
   return (
     <div>
       <Head>
@@ -16,10 +39,9 @@ export default function Home() {
         <div className="flex max-w-5xl mx-auto">
           <TopLeftMenu />
           <div className="flex flex-wrap pt-10 ml-3">
-            <TopProfile />
-            <TopProfile />
-            <TopProfile />
-            <TopProfile />
+            {teachers.map((teacher, index) => (
+              <TopProfile key={index} teacher={teacher} />
+            ))}
           </div>
         </div>
       </div>

--- a/pages/topTeacherDetail.js
+++ b/pages/topTeacherDetail.js
@@ -1,16 +1,46 @@
 import Header from "../components/common/header/header";
-import TeacherProfileDetail from "../components/teacher/profileDetail/TeacherProfileDetailCard";
+import TopTeacherProfileDetailCard from "../components/top/teacherDetail/TopTeacherProfileDetailCard";
 import Apply from "../components/top/teacherDetail/ApplyButton";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { db } from "../src/firabase";
+import { doc, getDoc } from "firebase/firestore";
 
 export default function TopTeacherDetail() {
+  const router = useRouter();
+  const id = router.query.id;
+  const [teacher, setTeacher] = useState({});
+
+  useEffect(() => {
+  const teacherRef = doc(db, "TeacherUsers", id);
+
+    getDoc(teacherRef).then((snapshot) => {
+      if (snapshot.data()) {
+        const user = snapshot.data();
+        console.log(user)
+        setTeacher({
+          name: user.name,
+          photo_url: user.photo_url,
+          occupation: user.occupation,
+          occupationName: user.occupationName,
+          category: user.category,
+          subjects: user.subjects,
+          title: user.title,
+          detail: user.detail,
+          consult: user.consult,
+        });
+      }
+    });
+  }, [setTeacher]);
+
   return (
     <>
       <Header />
       <div className="bg-top-bg h-screen">
         <div className="flex max-w-4xl m-auto py-10">
-          <TeacherProfileDetail />
+          <TopTeacherProfileDetailCard teacher={teacher}/>
           <div className="flex-column mx-10 px-10 w-[40rem] bg-white p-8 rounded text-gray-700">
-            <h1>全科目苦手克服方法を目指します！</h1>
+            <h1>{teacher.title}</h1>
             <div className="mt-5">
               <h1>自己紹介</h1>
               <p className="mt-2">

--- a/pages/topTeacherDetail.js
+++ b/pages/topTeacherDetail.js
@@ -10,6 +10,7 @@ export default function TopTeacherDetail() {
   const router = useRouter();
   const id = router.query.id;
   const [teacher, setTeacher] = useState({});
+  const [isDisplay, setIsDisplay] = useState(false)
 
   useEffect(() => {
   const teacherRef = doc(db, "TeacherUsers", id);
@@ -19,6 +20,7 @@ export default function TopTeacherDetail() {
         const user = snapshot.data();
         console.log(user)
         setTeacher({
+          id: snapshot.id,
           name: user.name,
           photo_url: user.photo_url,
           occupation: user.occupation,
@@ -31,7 +33,8 @@ export default function TopTeacherDetail() {
         });
       }
     });
-  }, [setTeacher]);
+    setIsDisplay(true);
+  },[]);
 
   return (
     <>
@@ -44,7 +47,7 @@ export default function TopTeacherDetail() {
             <div className="mt-5">
               <h1>自己紹介</h1>
               <p className="mt-2">
-                東京大学3年生の松丸慎吾です。偏差値30から現役で東大に入学することができました！
+                東京大学3年生の渚カヲルです。偏差値30から現役で東大に入学することができました！
                 個人に合わせた勉強方法を一緒に考えて、希望大学に合わせて一緒に勉強しませんか？
                 ご連絡お待ちしております！！
               </p>


### PR DESCRIPTION
Closes #53 

**追加機能**
-  firebaseから先生の情報を取得。
-  表示ステータスがONの先生ユーザカードを出力。
-  カードをクリックすると、個々の先生の詳細画面（Top 先生プロフィール詳細）に遷移する。

**issue以外の機能**
- 画面遷移には、先生IDをクエリに入れて、遷移先で選択された先生IDの情報をfirabeseから再取得している。
- 先生詳細画面（TopTeacherProfileCard）で利用するプロフィールカードは、今回Top用に新規作成した。プロフィールカード（TopTeacherProfileDetailCard）には、詳細画面からpropsで値を渡している。　