### PR TITLE
コース受講履歴用テーブル作成（Records）と、それに伴う変更

### DIFF
--- a/components/student/attendanceStatus/FinishButton.js
+++ b/components/student/attendanceStatus/FinishButton.js
@@ -10,8 +10,8 @@ export default function Finish(props) {
   const student = useRecoilValue(studentUserState)
 
   const handleFinish = async() => {
-    const CourseRef = await doc(db, "Courses", course.id, "students", student.id);
-    await updateDoc(CourseRef, { status: "終了申請中", finish_date: serverTimestamp()})
+    const CourseRef = await doc(db, "Courses", course.id, "students", student.id); 
+    await updateDoc(CourseRef, { status: "終了申請中", finish_date: serverTimestamp()}) 
 
     // 生徒情報を取得
     (async () => {

--- a/components/teacher/myStudentDetail/FinishApproveButton.js
+++ b/components/teacher/myStudentDetail/FinishApproveButton.js
@@ -1,22 +1,44 @@
-import { doc, getDoc, serverTimestamp, updateDoc } from "firebase/firestore";
+import { collection, deleteDoc, doc, getDoc, setDoc, Timestamp } from "firebase/firestore";
+import { useRecoilValue } from "recoil";
 import { db } from "../../../src/firabase";
+import { teacherUserState } from "../../common/TeacherAtoms";
 
 export default function FinishApprove(props) {
+  const teacher = useRecoilValue(teacherUserState);
   const { course, setStudent } = props;
 
   const handleApprove = () => {
-    const CourseRef = doc(db, "Courses", course.courseId, "students", course.studentId);
-    updateDoc(CourseRef, { status: "終了" })
+    (async () => {
+      const CourseRef = doc(db, "Courses", course.courseId, "students", course.studentId);
+      const CourseSnap = await getDoc(CourseRef);
+      const student_status = CourseSnap.data();
+      const start_date = student_status.start_date.toDate();
+      const finish_date = student_status.finish_date.toDate();
 
-    // 生徒情報を取得
-    const StudentRef = getDoc(doc(db, "StudentUsers", course.studentId))
-    StudentRef.then(snapshot => {
-      if (snapshot.data()) {
-        const studentId = snapshot.id;
-        const student = snapshot.data();
-        setStudent({studentId, student});
-    }})
+      const RecordsRef = doc(collection(db, "Records"));
+      await setDoc(RecordsRef, { 
+        courseID: course.courseId, 
+        course_name: course.courseName, 
+        course_price: course.coursePrice, 
+        teacherID: teacher.id,
+        studentID: course.studentId, 
+        student_name: student_status.name, 
+        start_date: Timestamp.fromDate(new Date(start_date)),
+        finish_date: Timestamp.fromDate(new Date(finish_date)),
+      })
 
+      await deleteDoc(CourseRef)
+
+      // 生徒情報を取得
+      const StudentRef = getDoc(doc(db, "StudentUsers", course.studentId))
+      StudentRef.then(snapshot => {
+        if (snapshot.data()) {
+          const studentId = snapshot.id;
+          const student = snapshot.data();
+          setStudent({studentId, student});
+      }})
+
+    })()
   }
 
   return (

--- a/components/teacher/myStudentDetail/ShowProfileContentBox.js
+++ b/components/teacher/myStudentDetail/ShowProfileContentBox.js
@@ -4,12 +4,11 @@ import FinishApprove from "./FinishApproveButton";
 import FinishCancel from "./FinishCancelButton";
 
 export default function ShowProfileContent(props) {
-  const { courses, student, setStudent } = props;
-  console.log(courses, student)
+  const { courses, student, records, setStudent } = props;
+
   const apply_status = courses.filter(course => course.studentInfo?.status == "申請中");
   const pending_status = courses.filter(course => course.studentInfo?.status == "受講中");
   const finishApply_status = courses.filter(course => course.studentInfo?.status == "終了申請中");
-  const finish_status = courses.filter(course => course.studentInfo?.status == "終了");
 
   return (
     <div className="flex-column mx-10 w-[40rem] bg-white p-8 rounded text-gray-700">
@@ -27,7 +26,6 @@ export default function ShowProfileContent(props) {
                 <Tr key={index}>
                 <Td><p className="text-sm">{course.courseName}</p></Td>
                 <Td><p className="text-sm">{course.coursePrice}円</p></Td>
-                {console.log(course)}
                 <Td px={1}><Approve course={course} student={student} setStudent={setStudent} /></Td>
                 </Tr>
               ))}
@@ -38,7 +36,7 @@ export default function ShowProfileContent(props) {
 
         { pending_status.length > 0 && (
           <>
-          <h1 className="mb-3 font-bold">受講中のコース</h1> 
+          <h1 className="my-5 font-bold">受講中のコース</h1> 
             <Table>
             <Thead>
               <Tr>
@@ -90,7 +88,7 @@ export default function ShowProfileContent(props) {
           </>
         )}
 
-        { finish_status.length > 0 && (
+        { records.length > 0 && (
           <>
           <h1 className="my-5 font-bold">受講履歴</h1> 
             <Table>
@@ -103,12 +101,12 @@ export default function ShowProfileContent(props) {
               </Tr>
             </Thead>
             <Tbody>
-              {finish_status.map((course, index) => (
+              {records.map((record, index) => (
                 <Tr key={index}>
-                <Td><p className="text-sm">{course.courseName}</p></Td>
-                <Td><p className="text-sm">{course.coursePrice}円</p></Td>
-                <Td><p className="text-sm">{`${course.studentInfo.start_date.toDate().getMonth()+1}月${course.studentInfo.start_date.toDate().getDate()}日`}</p></Td>
-                <Td><p className="text-sm">{`${course.studentInfo.finish_date.toDate().getMonth()+1}月${course.studentInfo.finish_date.toDate().getDate()}日`}</p></Td>
+                <Td><p className="text-sm">{record.course_name}</p></Td>
+                <Td><p className="text-sm">{record.course_price}円</p></Td>
+                <Td><p className="text-sm">{`${record.start_date.toDate().getMonth()+1}月${record.start_date.toDate().getDate()}日`}</p></Td>
+                <Td><p className="text-sm">{`${record.finish_date.toDate().getMonth()+1}月${record.finish_date.toDate().getDate()}日`}</p></Td>
                 </Tr>
               ))}
             </Tbody>

--- a/pages/achievement.js
+++ b/pages/achievement.js
@@ -19,24 +19,16 @@ export default function Achievement() {
   const [achievement, setAchievement] = useState([]);
 
   useEffect(() => {
-    const coursesRef = collection(db, "Courses");
-    const q = query(coursesRef, where("teacherID", "==", teacher.id));
-
-    getDocs(q).then(snapshot => {
-      snapshot.docs.map((doc)=> {
-        const courseRef = doc.data();
-        const courseId = doc.id;
-
-        const studentsRef = getDocs(collection(db, "Courses", courseId, "students"));
-        studentsRef.then(snapshot => {
-          const achievement = snapshot.docs.map((doc)=> {
-            const studentRef = doc.data();
-            return { ...studentRef, courseRef }
-          })
-          setAchievement(achievement);
+    (async () => {
+      const RecordsRef = collection(db, "Records");
+      const q = query(RecordsRef, where("teacherID", "==", teacher.id));
+      getDocs(q).then((snapshot) => {
+        const records = snapshot.docs.map((doc) => {
+          return doc.data();
         })
-      })
+        setAchievement(records);
     })
+    })()  
   },[])
   
 
@@ -44,29 +36,31 @@ export default function Achievement() {
     <>
       <Header />
       <div className="bg-top-bg w-screen h-screen">
-        <div className="flex max-w-6xl mx-auto py-10">
+        <div className="flex max-w-5xl mx-auto py-10 h-screen">
           <TeacherLeftMenu />
-          <div>
-            <Table>
-              <Thead>
-                <Tr>
-                  <Th>コース名</Th>
-                  <Th>生徒</Th>
-                  <Th>開始日</Th>
-                  <Th>終了日</Th>
-                </Tr>
-              </Thead>
-              <Tbody>
+          <div className="max-w-3xl text-sm pr-5">
+            <table>
+              <thead>
+                <tr className="font-bold text-gray-600">
+                  <td className="w-[250px]">コース名</td>
+                  <td className="w-[110px]">値段</td>
+                  <td className="w-[100px]">生徒</td>
+                  <td className="w-[100px]">開始日</td>
+                  <td className="w-[100px]">終了日</td>
+                </tr>
+              </thead>
+              <tbody>
                 {achievement.map((value, index) => (
-                  <Tr key={index}>
-                  <Td>{value.courseRef.name}</Td>
-                  <Td>{value.name}</Td>
-                  <Td>{`${value.start_date.toDate().getMonth()+1}月${value.start_date.toDate().getDate()}日`}</Td>
-                  <Td>{`${value.finish_date.toDate().getMonth()+1}月${value.finish_date.toDate().getDate()}日`}</Td>
-                  </Tr>
+                  <tr key={index}>
+                  <td>{value.course_name}</td>
+                  <td>{value.course_price}円</td>
+                  <td>{value.student_name}</td>
+                  <td>{`${value.start_date.toDate().getMonth()+1}月${value.start_date.toDate().getDate()}日`}</td>
+                  <td>{`${value.finish_date.toDate().getMonth()+1}月${value.finish_date.toDate().getDate()}日`}</td>
+                  </tr>
                 ))}
-              </Tbody>
-            </Table>
+              </tbody>
+            </table>
           </div>
         </div>
       </div>

--- a/pages/attendanceStatus.js
+++ b/pages/attendanceStatus.js
@@ -1,7 +1,7 @@
 import Header from "../components/common/header/header";
 import StudentLeftMenu from "../components/student/common/StudentLeftMenu";
 import { useEffect, useState } from "react";
-import { collection, doc, getDoc, getDocs } from "firebase/firestore";
+import { collection, doc, getDoc, getDocs, query, where } from "firebase/firestore";
 import { db } from "../src/firabase";
 import { studentUserState } from "../components/common/StudentAtoms";
 import { useRecoilValue } from "recoil";
@@ -56,8 +56,20 @@ export default function AttendanceStatus() {
 
       setApplyStatus(courseListWithStudentInfo.filter(course => course.studentInfo.status == "申請中"));
       setPendingStatus(courseListWithStudentInfo.filter(course => course.studentInfo.status == "受講中" || course.studentInfo.status == "終了申請中"));
-      setFinishStatus(courseListWithStudentInfo.filter(course => course.studentInfo.status == "終了"));
     })();
+  },[courses])
+
+  useEffect(() => {
+    (async () => {
+      const RecordsRef = collection(db, "Records");
+      const q = query(RecordsRef, where("studentID", "==", student.id));
+      getDocs(q).then((snapshot) => {
+        const records = snapshot.docs.map((doc) => {
+          return doc.data();
+        })
+        setFinishStatus(records);
+    })
+    })()  
   },[courses])
 
   return (
@@ -159,10 +171,10 @@ export default function AttendanceStatus() {
                 <Tbody>
                     {finishStatus.map((course, index) => (
                     <Tr key={index} className="text-sm">
-                    <Td><p>{course.courseInfo.name}</p></Td>
-                    <Td><p>{course.courseInfo.price}</p></Td>
-                    <Td>{`${course.studentInfo.start_date.toDate().getMonth()+1}月${course.studentInfo.start_date.toDate().getDate()}日`}</Td>
-                    <Td>{`${course.studentInfo.finish_date.toDate().getMonth()+1}月${course.studentInfo.finish_date.toDate().getDate()}日`}</Td>
+                    <Td><p>{course.course_name}</p></Td>
+                    <Td><p>{course.course_price}</p></Td>
+                    <Td>{`${course.start_date.toDate().getMonth()+1}月${course.start_date.toDate().getDate()}日`}</Td>
+                    <Td>{`${course.finish_date.toDate().getMonth()+1}月${course.finish_date.toDate().getDate()}日`}</Td>
                     </Tr>
                   ))}
                 </Tbody>

--- a/pages/myStudentDetail.js
+++ b/pages/myStudentDetail.js
@@ -17,6 +17,7 @@ export default function TopTeacherDetail() {
   const [coursesList, setCoursesList] = useState([]);
   const [student, setStudent] = useState({});
   const [courses, setCourses] = useState([]);
+  const [records, setRecords] = useState([]);
 
   useEffect(() => {
     // 生徒情報を取得
@@ -64,9 +65,21 @@ export default function TopTeacherDetail() {
       
     }))
     setCourses(courseListWithStudentInfo)
-    console.log(courseListWithStudentInfo)
   })()
   },[coursesList])
+
+  // 生徒の受講履歴を取得
+  useEffect(() => {
+    const RecordsRef = collection(db, "Records");
+    const q1 = query(RecordsRef, where("studentID", "==", studentId));
+    const q2 = query(q1, where("teacherID", "==", teacher.id))
+    getDocs(q2).then((snapshot) => {
+      const records = snapshot.docs.map((doc) => {
+        return doc.data();
+      })
+      setRecords(records);
+    })
+  },[courses]);
 
   return (
     <>
@@ -82,7 +95,7 @@ export default function TopTeacherDetail() {
             </p>
             <div className="flex">
               <MyStudentProfileDetailCard student={student}/>
-              <ShowProfileContent courses={courses} student={student} setStudent={setStudent} />
+              <ShowProfileContent courses={courses} student={student} records={records} setStudent={setStudent} />
             </div>
           </div>
         </div>

--- a/pages/myStudents.js
+++ b/pages/myStudents.js
@@ -121,7 +121,7 @@ export default function MyStudents() {
             </div>
             <div className="mt-5">
             <h1 className="font-bold text-sm">受講中の生徒</h1>
-                <div className="mt-5">
+                <div className="mt-5 flex">
                 {pendingStatus.map((course) => (
                 <>
                 <MyStudentProfile course={course} />


### PR DESCRIPTION
Closes #119 

**変更点**

- 新規に終了したコース情報を保存するRecordsテーブルを作成した。
- 先生マイページの生徒一覧ページにて、実績出力にRecordsから取得するよう実装。
- 先生マイページの生徒詳細ページ終了ボタンを押下した場合に、Coursesから該当のCourseドキュメントを削除し、Recordsに登録する処理を実装。
- 生徒マイページの受講状況ページの終了したコースについては、Recordsから取得するよう実装。
- 先生マイページの実績ページについて、全てRecordsから取得するよう修正。
